### PR TITLE
custom pumpkin opacity

### DIFF
--- a/src/main/java/club/sk1er/patcher/config/PatcherConfig.java
+++ b/src/main/java/club/sk1er/patcher/config/PatcherConfig.java
@@ -191,6 +191,7 @@ public class PatcherConfig extends Config {
         min = 0F, max = 1.0F
     )
     public static float fireOverlayOpacity = 1.0F;
+
     @Slider( // todo add percentage
         name = "Pumpkin Overlay Opacity",
         description = "Change the opacity of the pumpkin overlay.",
@@ -198,7 +199,6 @@ public class PatcherConfig extends Config {
         min = 0F, max = 1.0F
     )
     public static float pumpkinOverlayOpacity = 1.0F;
-
 
     @Switch(
         name = "Hide Fire Overlay with Fire Resistance",

--- a/src/main/java/club/sk1er/patcher/config/PatcherConfig.java
+++ b/src/main/java/club/sk1er/patcher/config/PatcherConfig.java
@@ -191,6 +191,14 @@ public class PatcherConfig extends Config {
         min = 0F, max = 1.0F
     )
     public static float fireOverlayOpacity = 1.0F;
+    @Slider( // todo add percentage
+        name = "Pumpkin Overlay Opacity",
+        description = "Change the opacity of the pumpkin overlay.",
+        category = "Miscellaneous", subcategory = "Overlays",
+        min = 0F, max = 1.0F
+    )
+    public static float pumpkinOverlayOpacity = 1.0F;
+
 
     @Switch(
         name = "Hide Fire Overlay with Fire Resistance",

--- a/src/main/java/club/sk1er/patcher/mixins/features/GuiIngameMixin_PumpkinBlurRendering.java
+++ b/src/main/java/club/sk1er/patcher/mixins/features/GuiIngameMixin_PumpkinBlurRendering.java
@@ -1,0 +1,23 @@
+package club.sk1er.patcher.mixins.features;
+
+import club.sk1er.patcher.config.PatcherConfig;
+import net.minecraft.client.gui.GuiIngame;
+import net.minecraft.client.gui.ScaledResolution;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(GuiIngame.class)
+public class GuiIngameMixin_PumpkinBlurRendering {
+    @Inject(method = "renderPumpkinOverlay", at = @At("HEAD"), cancellable = true)
+    private void patcher$cancelPumpkinOverlay(ScaledResolution scaledRes, CallbackInfo ci) {
+        if (PatcherConfig.pumpkinOverlayOpacity == 0) ci.cancel();
+    }
+
+    @ModifyArg(method = "renderPumpkinOverlay", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/GlStateManager;color(FFFF)V"), index = 3)
+    private float patcher$modifyPumpkinOpacity(float alpha) {
+        return PatcherConfig.pumpkinOverlayOpacity;
+    }
+}

--- a/src/main/java/club/sk1er/patcher/mixins/features/GuiIngameMixin_PumpkinBlurRendering.java
+++ b/src/main/java/club/sk1er/patcher/mixins/features/GuiIngameMixin_PumpkinBlurRendering.java
@@ -13,7 +13,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public class GuiIngameMixin_PumpkinBlurRendering {
     @Inject(method = "renderPumpkinOverlay", at = @At("HEAD"), cancellable = true)
     private void patcher$cancelPumpkinOverlay(ScaledResolution scaledRes, CallbackInfo ci) {
-        if (PatcherConfig.pumpkinOverlayOpacity == 0) ci.cancel();
+        if (PatcherConfig.pumpkinOverlayOpacity == 0) ci.cancel(); // micro-optimization, let's skip all the math to render if it's not going to be visible anyways
     }
 
     @ModifyArg(method = "renderPumpkinOverlay", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/GlStateManager;color(FFFF)V"), index = 3)

--- a/src/main/resources/mixins.patcher.json
+++ b/src/main/resources/mixins.patcher.json
@@ -138,6 +138,7 @@
     "features.GuiIngameForgeMixin_CrosshairRendering",
     "features.GuiIngameForgeMixin_TitleRendering",
     "features.GuiIngameMixin_CrosshairVisibility",
+    "features.GuiIngameMixin_PumpkinBlurRendering",
     "features.GuiMultiplayerMixin_FastServerJoin",
     "features.GuiNewChatMixin_ChatDelay",
     "features.GuiNewChatMixin_CompactChat",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Allows customizing the opacity when wearing a pumpkin

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
blc alternatives feature :)

## How to test
<!-- Provide steps to test this PR -->
put pumpkin on head

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
+ Added custom pumpkin overlay opacity when wearing a pumpkin on your head
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->