### PR TITLE
fix: Imgur links not being previewed and extra extension sometimes be…

### DIFF
--- a/src/main/java/club/sk1er/patcher/screen/render/overlay/ImagePreview.java
+++ b/src/main/java/club/sk1er/patcher/screen/render/overlay/ImagePreview.java
@@ -82,7 +82,7 @@ public class ImagePreview {
             return;
         }
 
-        if (value.contains("imgur.com/")) {
+        if (value.contains("imgur.com/") && !value.contains("i.imgur")) {
             final String[] split = value.split("/");
             value = String.format("https://i.imgur.com/%s.png", split[split.length - 1]);
         }
@@ -156,6 +156,10 @@ public class ImagePreview {
             connection.setUseCaches(true);
             connection.setInstanceFollowRedirects(true);
             connection.addRequestProperty("User-Agent", "Patcher Image Previewer");
+            if (url.contains("imgur")) {
+                // Prevents redirect to main website
+                connection.addRequestProperty("Referer", "https://imgur.com/");
+            }
             connection.setReadTimeout(15000);
             connection.setConnectTimeout(15000);
             connection.setDoOutput(true);


### PR DESCRIPTION
…ing added (#169)

* Fix Imgur links not previewing & extra extension being added

* Remove unused import

Added this when debugging the issue and i forgor to remove 💀

## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->