### PR TITLE
text glstate fix

### DIFF
--- a/src/main/java/club/sk1er/patcher/config/PatcherConfig.java
+++ b/src/main/java/club/sk1er/patcher/config/PatcherConfig.java
@@ -1398,13 +1398,6 @@ public class PatcherConfig extends Config {
     )
     public static int cacheFPS = 20;
 
-    @Switch(
-        name = "Force Blend on Text",
-        description = "Forcefully applies blend to text rendering to attempt to fix black boxes.",
-        category = "Experimental", subcategory = "Text Rendering"
-    )
-    public static boolean forceTextBlending = false;
-
     // HIDDEN
 
     public static boolean labyModMoment = true;

--- a/src/main/java/club/sk1er/patcher/config/PatcherConfig.java
+++ b/src/main/java/club/sk1er/patcher/config/PatcherConfig.java
@@ -1398,6 +1398,13 @@ public class PatcherConfig extends Config {
     )
     public static int cacheFPS = 20;
 
+    @Switch(
+        name = "Force Blend on Text",
+        description = "Forcefully applies blend to text rendering to attempt to fix black boxes.",
+        category = "Experimental", subcategory = "Text Rendering"
+    )
+    public static boolean forceTextBlending = false;
+
     // HIDDEN
 
     public static boolean labyModMoment = true;

--- a/src/main/java/club/sk1er/patcher/mixins/bugfixes/FontRendererMixin_ResetBlend.java
+++ b/src/main/java/club/sk1er/patcher/mixins/bugfixes/FontRendererMixin_ResetBlend.java
@@ -15,8 +15,4 @@ public class FontRendererMixin_ResetBlend {
         if (PatcherConfig.forceTextBlending) GlStateManager.enableBlend();
     }
 
-    @Inject(method = "renderString", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/FontRenderer;renderStringAtPos(Ljava/lang/String;Z)V", shift = At.Shift.AFTER))
-    private void patcher$renderStringPost(String text, float x, float y, int color, boolean dropShadow, CallbackInfoReturnable<Integer> cir) {
-        if (PatcherConfig.forceTextBlending) GlStateManager.disableBlend();
-    }
 }

--- a/src/main/java/club/sk1er/patcher/mixins/bugfixes/FontRendererMixin_ResetBlend.java
+++ b/src/main/java/club/sk1er/patcher/mixins/bugfixes/FontRendererMixin_ResetBlend.java
@@ -12,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public class FontRendererMixin_ResetBlend {
     @Inject(method = "renderString", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/FontRenderer;renderStringAtPos(Ljava/lang/String;Z)V", shift = At.Shift.BEFORE))
     private void patcher$renderStringPre(String text, float x, float y, int color, boolean dropShadow, CallbackInfoReturnable<Integer> cir) {
-        if (PatcherConfig.forceTextBlending) GlStateManager.enableBlend();
+        GlStateManager.enableBlend();
     }
 
 }

--- a/src/main/java/club/sk1er/patcher/mixins/bugfixes/FontRendererMixin_ResetBlend.java
+++ b/src/main/java/club/sk1er/patcher/mixins/bugfixes/FontRendererMixin_ResetBlend.java
@@ -1,0 +1,22 @@
+package club.sk1er.patcher.mixins.bugfixes;
+
+import club.sk1er.patcher.config.PatcherConfig;
+import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.client.renderer.GlStateManager;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(FontRenderer.class)
+public class FontRendererMixin_ResetBlend {
+    @Inject(method = "renderString", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/FontRenderer;renderStringAtPos(Ljava/lang/String;Z)V", shift = At.Shift.BEFORE))
+    private void patcher$renderStringPre(String text, float x, float y, int color, boolean dropShadow, CallbackInfoReturnable<Integer> cir) {
+        if (PatcherConfig.forceTextBlending) GlStateManager.enableBlend();
+    }
+
+    @Inject(method = "renderString", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/FontRenderer;renderStringAtPos(Ljava/lang/String;Z)V", shift = At.Shift.AFTER))
+    private void patcher$renderStringPost(String text, float x, float y, int color, boolean dropShadow, CallbackInfoReturnable<Integer> cir) {
+        if (PatcherConfig.forceTextBlending) GlStateManager.disableBlend();
+    }
+}

--- a/src/main/resources/mixins.patcher.json
+++ b/src/main/resources/mixins.patcher.json
@@ -44,6 +44,7 @@
     "bugfixes.EntityRendererMixin_PolygonOffset",
     "bugfixes.EntityRendererMixin_SpectatorShader",
     "bugfixes.EntityXPOrbMixin_AdjustHeight",
+    "bugfixes.FontRendererMixin_ResetBlend",
     "bugfixes.FontRendererMixin_ResetStyles",
     "bugfixes.GameSettingsMixin_MipmapSlider",
     "bugfixes.GuiContainerMixin_SplitRemnants",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
yes this is not the right way to do this really, but tracking down the actual issue has been a pain. i am not aware of any issues this causes currently. i have asked people to test and in my own testing it seems to work with no discernible issues. we wont have this problem if we switch to 1.21+ anyways :pray:. toggle did something similar in recent commits so i decided to pr this

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
N/A

## How to test
<!-- Provide steps to test this PR -->
if you already have the issue, then adding the mod should fix it. otherwise, using an old vanillahud alpha build that used to have the problem when tab was open is how i tested it

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
Fix black text backgrounds and blocky text
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->